### PR TITLE
let PointcloudScreenpoint always subscribe input pointcloud

### DIFF
--- a/hironx_tutorial/euslisp/simple-screen-point-test.l
+++ b/hironx_tutorial/euslisp/simple-screen-point-test.l
@@ -1,0 +1,35 @@
+#!/usr/bin/env roseus
+
+(ros::roseus "simple-screen-point-test")
+(ros::load-ros-package "jsk_recognition_msgs")
+(setq *ray_srv* "/pointcloud_screenpoint_nodelet/screen_to_point")
+
+(load "package://hrpsys_ros_bridge_tutorials/euslisp/hironxjsk-interface.l")
+(hironxjsk-init)
+
+(defun look-table ()
+  (send *hironxjsk* :reset-manip-pose)
+  (send *hironxjsk* :head :look-at
+        (send (send (send *hironxjsk* :torso :end-coords :copy-worldcoords)
+                    :translate #f(750 0 0)) :worldpos))
+  (send *ri* :angle-vector (send *hironxjsk* :angle-vector) 1000)
+  (send *ri* :wait-interpolation))
+
+(look-table)
+
+(let* ((x 240)
+	   (y 320)
+	   (req (instance jsk_recognition_msgs::TransformScreenpointRequest :init
+                      :x x :y y))
+	   res)
+  (format t "x y ~A ~A~%" x y)
+  (format t ";;wait for service~%")
+  (ros::wait-for-service *ray_srv*)
+  (setq res (ros::service-call *ray_srv* req))
+  (format t "food coords is ~A ~A ~A ~%"
+          (send (send res :vector) :x)
+          (send (send res :vector) :y)
+          (send (send res :vector) :z))
+  )
+
+(ros::exit)

--- a/hironx_tutorial/launch/hiro_lunch_box.launch
+++ b/hironx_tutorial/launch/hiro_lunch_box.launch
@@ -38,7 +38,7 @@
     <arg name="camera_info" value="/head_camera/rgb/camera_info"/>
     </include -->
   <node name="pointcloud_screenpoint_nodelet" pkg="nodelet" type="nodelet"
-        args="load jsk_pcl/PointcloudScreenpoint screenpoint_manager"
+        args="standalone jsk_pcl/PointcloudScreenpoint"
         output="screen" clear_params="true" respawn="true"
         machine="$(arg cloud_machine)">
     <remap from="~points" to="$(arg inpoints)" />
@@ -46,12 +46,10 @@
     <remap from="~rect" to="$(arg image)/$(arg image_type)/screenrectangle" />
     <remap from="~point_array" to="$(arg image)/$(arg image_type)/screenpoint_array" />
     <rosparam>
+      always_subscribe: true
       queue_size: 10
       crop_size: 10
       search_size: 16
-      use_rect: false
-      use_point_array: true
-      use_point: true
       publish_point: true
     </rosparam>
     <param name="use_sync" value="$(arg USE_SYNC)" />


### PR DESCRIPTION
メールで詳細を書こうと思いますが、`PointcloudScreenpoint`に`always_subscribe:=true`というrosparamを足しました。

以下のコマンドで、Coralに依存しない形で`PointcloudScreenpoint`のテストが出来るかと思います。
```bash
# Terminal 1
roslaunch hironx_tutorial hiro_lunch_box.launch launch_rviz:=false
# Terminal 2
rosrun hironx_tutorial simple-screen-point-test.l
```

また自分のPCの具合が悪いのか、`PointcloudScreenpoint`をnodeletとしてloadすると上手く動かなかったので、standaloneにしています。

このプルリクエストはマージしてくれてもしてくれなくても大丈夫です。
参考にしてプログラムを変更してあげてください。