### PR TITLE
use topic to call PointcloudScreenpoint

### DIFF
--- a/hironx_tutorial/euslisp/simple-screen-point-test.l
+++ b/hironx_tutorial/euslisp/simple-screen-point-test.l
@@ -1,0 +1,49 @@
+#!/usr/bin/env roseus
+
+(ros::roseus "simple-screen-point-test")
+(ros::load-ros-package "geometry_msgs")
+(setq *pub-topic* "/head_camera/rgb/image_rect_color/screenpoint")
+(setq *sub-topic* "/pointcloud_screenpoint_nodelet/output_point")
+
+(load "package://hrpsys_ros_bridge_tutorials/euslisp/hironxjsk-interface.l")
+(hironxjsk-init)
+
+(defun look-table ()
+  (send *hironxjsk* :reset-manip-pose)
+  (send *hironxjsk* :head :look-at
+        (send (send (send *hironxjsk* :torso :end-coords :copy-worldcoords)
+                    :translate #f(750 0 0)) :worldpos))
+  (send *ri* :angle-vector (send *hironxjsk* :angle-vector) 1000)
+  (send *ri* :wait-interpolation))
+
+(defun cb (msg)
+  (format t "food coords is ~A ~A ~A ~%"
+          (send (send msg :point) :x)
+          (send (send msg :point) :y)
+          (send (send msg :point) :z)))
+
+
+(ros::advertise *pub-topic* geometry_msgs::PointStamped 1)
+(ros::subscribe *sub-topic* geometry_msgs::PointStamped #'cb)
+
+;; main
+
+(look-table)
+
+(let* ((x 240)
+	   (y 320)
+	   (pub-msg (instance geometry_msgs::Pointstamped :init)))
+  ;; publish
+  (format t "x y ~A ~A~%" x y)
+  (send pub-msg :header :stamp (ros::time-now))
+  (send pub-msg :header :frame_id "head_camera_rgb_optical_frame")
+  (send (send pub-msg :point) :x x)
+  (send (send pub-msg :point) :y y)
+  (send (send pub-msg :point) :z 0)
+  (ros::publish *pub-topic* pub-msg)
+  ;; subscribe
+  (unix:usleep (* 100 1000))
+  (ros::spin-once)
+  )
+
+(ros::exit)

--- a/hironx_tutorial/launch/hiro_lunch_box.launch
+++ b/hironx_tutorial/launch/hiro_lunch_box.launch
@@ -38,24 +38,17 @@
     <arg name="camera_info" value="/head_camera/rgb/camera_info"/>
     </include -->
   <node name="pointcloud_screenpoint_nodelet" pkg="nodelet" type="nodelet"
-        args="load jsk_pcl/PointcloudScreenpoint screenpoint_manager"
+        args="standalone jsk_pcl/PointcloudScreenpoint"
         output="screen" clear_params="true" respawn="true"
         machine="$(arg cloud_machine)">
     <remap from="~points" to="$(arg inpoints)" />
     <remap from="~point" to="$(arg image)/$(arg image_type)/screenpoint" />
-    <remap from="~rect" to="$(arg image)/$(arg image_type)/screenrectangle" />
-    <remap from="~point_array" to="$(arg image)/$(arg image_type)/screenpoint_array" />
     <rosparam>
       queue_size: 10
       crop_size: 10
       search_size: 16
-      use_rect: false
-      use_point_array: true
-      use_point: true
-      publish_point: true
     </rosparam>
     <param name="use_sync" value="$(arg USE_SYNC)" />
-    <param name="publish_points" value="$(arg PUBLISH_POINTS)" />
   </node>
   
   


### PR DESCRIPTION
https://github.com/MiyabiTane/rtmros_tutorials/pull/1 とは別の作戦として、topicで`PointcloudScreenpoint`を呼ぶためのサンプルプログラムを作りました。

プログラムを動かすのに必要な通信量や計算量を考えると、こちらを使うようにしたほうが良いかもしれません。

使い方は以下のとおりです。
```bash
# Terminal 1
roslaunch hironx_tutorial hiro_lunch_box.launch launch_rviz:=false
# Terminal 2
rosrun hironx_tutorial simple-screen-point-test.l
```