### PR TITLE
Run tabletop_object_detector.launch correctly in hiro_lunch_box.launch

### DIFF
--- a/hironx_tutorial/launch/hiro_lunch_box.launch
+++ b/hironx_tutorial/launch/hiro_lunch_box.launch
@@ -18,8 +18,11 @@
   <arg name="PUBLISH_POINTS" default="false"/>
   <arg name="manager" default="hiro_lunch_box_nodelet_manager"/>
   
+  <!-- nodelet manager is executed by tabletop_object_detector.launch -->
+  <!--
   <node name="$(arg manager)" pkg="nodelet" type="nodelet" args="manager"
         machine="$(arg cloud_machine)" output="screen" />
+  -->
   
   <group if="$(arg gazebo)">
     <arg name="paused" default="false" />
@@ -35,7 +38,9 @@
     <arg name="input" value="/head_camera/depth_registered/points" />
     <arg name="sensor_frame" value="head_camera_rgb_optical_frame" />
     <arg name="manager" value="$(arg manager)" />
-    <arg name="launch_manager" value="false" />
+    <arg name="machine" value="$(arg cloud_machine)" />
+    <!-- <arg name="launch_manager" value="false" /> -->  <!-- This prevents multi_plane_estimate from running -->
+    <arg name="launch_manager" value="true" />
     <arg name="launch_openni" value="false" />
     <arg name="launch_tracking" value="false" />
     <arg name="launch_rviz" value="false" />


### PR DESCRIPTION
Closes #4 
![Screenshot 2020-05-25 21:52:45](https://user-images.githubusercontent.com/14994939/82814904-05c05400-9ed3-11ea-947c-c7cc7df99e16.png)

https://github.com/jsk-ros-pkg/jsk_recognition/blob/1.2.10/jsk_pcl_ros/sample/tabletop_object_detector.launch#L39
を見ると、`if="$(arg launch_manager)"`とあると思うんですが、これは、`launch_manager`がtrueの時だけこのxmlタグを実行しますよ、という意味になります。
http://wiki.ros.org/roslaunch/XML#if_and_unless_attributes
これが`multi_plane_estimate`ノードのタグに書かれていて、元のhiro_lunch_box.launchではtabletop_object_detector.launchの`launch_manager`にfalseを渡しているので、`multi_plane_estimate`ノードが実行されず、それ以下のパイプラインが全部動いていない、ということです。

今回の場合、nodeletをtabletop_object_detector.launchの外部で実行する必要性は薄そうだったので、内部で実行して、`machine`に`cloud_machine`を渡しておきました。
https://github.com/jsk-ros-pkg/jsk_recognition/blob/1.2.10/jsk_pcl_ros/sample/tabletop_object_detector.launch#L27-L29
ただ、`machine`を設定する必要性などが汲み取れていなくて、もしかしたら意図しない方向に直しているかもしれないです。

また、赤い箱のbounding boxが傾いてしまっているんですが、これは上面の点群が抜けていて、得られる点群が少なく、少ない点群から長軸を求めた結果傾いてしまっているかもしれません。
これは弁当箱でしょうか？
もしそうなら、上面が抜けていて正解で、上面が抜けていてもできるようにしないといけないので、ちょっとパラメータチューニングが必要になりそうです。