### PR TITLE
Fix usage of AttentionClipper in hiro_lunch_box.launch

### DIFF
--- a/hironx_tutorial/config/hiro_lunch_box.rviz
+++ b/hironx_tutorial/config/hiro_lunch_box.rviz
@@ -1,0 +1,367 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 78
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Status1
+      Splitter Ratio: 0.5
+    Tree Height: 912
+  - Class: rviz/Selection
+    Name: Selection
+  - Class: rviz/Tool Properties
+    Expanded:
+      - /2D Pose Estimate1
+      - /2D Nav Goal1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.588679016
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: PointCloud2
+Toolbars:
+  toolButtonStyle: 2
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.0299999993
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Alpha: 1
+      Class: rviz/RobotModel
+      Collision Enabled: false
+      Enabled: true
+      Links:
+        All Links Enabled: true
+        CHEST_JOINT0_Link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        Expand Joint Details: false
+        Expand Link Details: false
+        Expand Tree: false
+        HEAD_JOINT0_Link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        HEAD_JOINT1_Link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LARM_JOINT0_Link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LARM_JOINT1_Link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LARM_JOINT2_Link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LARM_JOINT3_Link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LARM_JOINT4_Link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LARM_JOINT5_Link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LHAND_JOINT0_Link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LHAND_JOINT1_Link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LHAND_JOINT2_Link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LHAND_JOINT3_Link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        Link Tree Style: Links in Alphabetic Order
+        RARM_JOINT0_Link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        RARM_JOINT1_Link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        RARM_JOINT2_Link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        RARM_JOINT3_Link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        RARM_JOINT4_Link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        RARM_JOINT5_Link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        RHAND_JOINT0_Link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        RHAND_JOINT1_Link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        RHAND_JOINT2_Link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        RHAND_JOINT3_Link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        WAIST:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        head_camera_depth_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        head_camera_depth_optical_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        head_camera_rgb_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        head_camera_rgb_optical_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        head_end_coords:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        larm_end_coords:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        lhsensor:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        odom:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        rarm_end_coords:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        rhsensor:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+      Name: RobotModel
+      Robot Description: robot_description
+      TF Prefix: ""
+      Update Interval: 0
+      Value: true
+      Visual Enabled: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz/PointCloud2
+      Color: 255; 255; 255
+      Color Transformer: RGB8
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 4096
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: PointCloud2
+      Position Transformer: XYZ
+      Queue Size: 10
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.00999999978
+      Style: Points
+      Topic: /head_camera/depth_registered/points
+      Unreliable: false
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
+    - Alpha: 1
+      Class: jsk_rviz_plugin/PolygonArray
+      Color: 25; 255; 0
+      Enabled: true
+      Name: PolygonArray
+      Topic: /multi_plane_estimate/output_refined_polygon
+      Unreliable: false
+      Value: true
+      coloring: Auto
+      enable lighting: true
+      normal length: 0.100000001
+      only border: true
+      show normal: true
+    - Class: jsk_rviz_plugin/BoundingBoxArray
+      Enabled: true
+      Name: BoundingBoxArray
+      Topic: /segmentation_decomposer/boxes
+      Unreliable: false
+      Value: true
+      alpha: 0.800000012
+      color: 25; 255; 0
+      coloring: Flat color
+      line width: 0.00499999989
+      only edge: true
+      show coords: true
+    - Class: rviz/InteractiveMarkers
+      Enable Transparency: true
+      Enabled: false
+      Name: InteractiveMarkers
+      Show Axes: false
+      Show Descriptions: true
+      Show Visual Aids: false
+      Update Topic: /bounding_box_interactive_marker/update
+      Value: false
+    - Class: jsk_rviz_plugin/BoundingBoxArray
+      Enabled: true
+      Name: AttentionClipperBox
+      Topic: /attention_clipper/output/box_array
+      Unreliable: false
+      Value: true
+      alpha: 0.800000012
+      color: 0; 25; 255
+      coloring: Flat color
+      line width: 0.00499999989
+      only edge: true
+      show coords: false
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Default Light: true
+    Fixed Frame: odom
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/MoveCamera
+    - Class: rviz/Select
+    - Class: rviz/FocusCamera
+    - Class: rviz/Measure
+    - Class: rviz/SetInitialPose
+      Topic: /initialpose
+    - Class: rviz/SetGoal
+      Topic: /move_base_simple/goal
+    - Class: rviz/PublishPoint
+      Single click: true
+      Topic: /clicked_point
+  Value: true
+  Views:
+    Current:
+      Class: rviz/Orbit
+      Distance: 2.73748064
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.0599999987
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: 0.30131337
+        Y: 0.635118902
+        Z: 0.506525278
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.0500000007
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.00999999978
+      Pitch: 0.540397882
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz)
+      Yaw: 5.10859299
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 1299
+  Hide Left Dock: false
+  Hide Right Dock: true
+  QMainWindow State: 000000ff00000000fd00000004000000000000020800000442fc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000006f00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000004000000442000000fa00fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000016c00000442fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000004000000442000000e500fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e100000197000000030000089000000058fc0100000002fb0000000800540069006d00650100000000000008900000057800fffffffb0000000800540069006d006501000000000000045000000000000000000000067c0000044200000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: true
+  Width: 2192
+  X: 130
+  Y: 60

--- a/hironx_tutorial/launch/hiro_lunch_box.launch
+++ b/hironx_tutorial/launch/hiro_lunch_box.launch
@@ -91,6 +91,9 @@
         pkg="jsk_pcl_ros" type="extract_indices">
     <remap from="~input" to="$(arg INPUT_CLOUD)" />
     <remap from="~indices" to="attention_clipper/output/point_indices" />
+    <rosparam>
+      keep_organized: true
+    </rosparam>
   </node>
   
   

--- a/hironx_tutorial/launch/hiro_lunch_box.launch
+++ b/hironx_tutorial/launch/hiro_lunch_box.launch
@@ -69,8 +69,6 @@
 
 
   <!-- attention_clipper -->
-  <include file="$(find jsk_pcl_ros_utils)/sample/include/play_rosbag_shelf_bin.xml" />
-
   <arg name="INPUT_CLOUD" value="/head_camera/depth_registered/points" />
 
   <node name="attention_clipper"

--- a/hironx_tutorial/launch/hiro_lunch_box.launch
+++ b/hironx_tutorial/launch/hiro_lunch_box.launch
@@ -73,7 +73,7 @@
 
   <node name="attention_clipper"
         pkg="nodelet" type="nodelet"
-        args="standalone jsk_pcl/AttentionClipper">
+        args="load jsk_pcl/AttentionClipper $(arg manager)">
     <remap from="~input/points" to="$(arg INPUT_CLOUD)" />
     <rosparam>
       initial_pos: [0.0, -0.05, 0.7]
@@ -86,7 +86,8 @@
   </node>
 
   <node name="extract_indices"
-        pkg="jsk_pcl_ros" type="extract_indices">
+        pkg="nodelet" type="nodelet"
+        args="load jsk_pcl/ExtractIndices $(arg manager)">
     <remap from="~input" to="$(arg INPUT_CLOUD)" />
     <remap from="~indices" to="attention_clipper/output/point_indices" />
     <rosparam>

--- a/hironx_tutorial/launch/hiro_lunch_box.launch
+++ b/hironx_tutorial/launch/hiro_lunch_box.launch
@@ -100,7 +100,7 @@
   <group if="$(arg launch_rviz)">
     <node name="rviz"
           pkg="rviz" type="rviz"
-          args="-d $(find hironx_tutorial)/config/hironxjsk_picking_demo.rviz">
+          args="-d $(find hironx_tutorial)/config/hiro_lunch_box.rviz">
     </node>
   </group>
 

--- a/hironx_tutorial/launch/hiro_lunch_box.launch
+++ b/hironx_tutorial/launch/hiro_lunch_box.launch
@@ -76,12 +76,12 @@
         args="load jsk_pcl/AttentionClipper $(arg manager)">
     <remap from="~input/points" to="$(arg INPUT_CLOUD)" />
     <rosparam>
-      initial_pos: [0.0, -0.05, 0.7]
-      initial_rot: [0, 0, 0.05]
-      dimension_x: 0.3
-      dimension_y: 0.43
-      dimension_z: 0.4
-      frame_id: head_camera_rgb_optical_frame
+      initial_pos: [0.9, 0, 0]
+      initial_rot: [0, 0, 0]
+      dimension_x: 1.0
+      dimension_y: 1.0
+      dimension_z: 0.3
+      frame_id: WAIST
     </rosparam >
   </node>
 


### PR DESCRIPTION
Closes #6 

![Screenshot 2020-06-02 18:51:47](https://user-images.githubusercontent.com/14994939/83506470-340ce780-a502-11ea-8223-f110e0bfaa6a.png)

- OrganizedMultiPlaneSegmentationは、その名が示すように、organizedな点群に対して適用できるものです。
https://jsk-recognition.readthedocs.io/en/latest/jsk_pcl_ros/nodes/organized_multi_plane_segmentation.html#what-is-this
https://github.com/MiyabiTane/rtmros_tutorials/issues/6#issuecomment-637394646 のエラーメッセージでも、`Organized point cloud is required`と言っています。このような点群をExtractIndicesが出力するためには、`keep_organized`パラメータをtrueにしないといけません。
https://jsk-recognition.readthedocs.io/en/latest/jsk_pcl_ros/nodes/extract_indices.html#parameter
  - なお、organizedな点群とは何か、については、以下の67ページを見てみて下さい。
    https://www.slideshare.net/garaemon/ueda-cv-saisentan
- hiro_lunch_box.launchに、https://github.com/jsk-ros-pkg/jsk_recognition/blob/1.2.10/jsk_pcl_ros/sample/sample_attention_clipper.launch#L5 がそのままコピーされてしまっていますが、このrosbag playはロボット実機やシミュレータがない時に、記録しておいたセンサtopicをpublishするものなので、シミュレータから必要なtopicが出ている状態では不必要です。むしろ入れてしまうと、https://github.com/jsk-ros-pkg/jsk_recognition/blob/1.2.10/jsk_pcl_ros_utils/sample/include/play_rosbag_shelf_bin.xml#L7 のように`--clock`フラグがセットしてあるので、記録された時刻を`/clock`にpublishしますが、これがGazeboから出る`/clock`と干渉します。このせいで、`/clock`をsubscribeして現在時刻を知る他のnodeから見ると、現在時刻が飛びまくる状況になります（これが、https://github.com/MiyabiTane/rtmros_tutorials/issues/6#issuecomment-637394646 の`Detected jump back in time`の意味するところ）
- 高速化のため、attention_clipperとextract_indicesを独立したノードとして立ち上げるのではなく、nodeletに読み込ませました
- AttentionClipperの領域のバウンディングボックスをrvizに青色で表示するようにしました
- AttentionClipperの領域がテーブル周辺ではなかったので、テーブル周辺になるよう修正しました